### PR TITLE
Update vae.py

### DIFF
--- a/examples/generative/vae.py
+++ b/examples/generative/vae.py
@@ -91,7 +91,7 @@ class VAE(keras.Model):
             reconstruction = self.decoder(z)
             reconstruction_loss = tf.reduce_mean(
                 tf.reduce_sum(
-                    keras.losses.binary_crossentropy(data, reconstruction), axis=(1, 2)
+                    keras.losses.binary_crossentropy(data[0], reconstruction), axis=(1, 2)
                 )
             )
             kl_loss = -0.5 * (1 + z_log_var - tf.square(z_mean) - tf.exp(z_log_var))


### PR DESCRIPTION
Correct argument `data` interpretation in `train_step`. This is a tuple of form `(tf.tensor, )` so needs to be unpacked before being passed to the loss function. The argument `reconstruction` is a `tf.tensor` already.